### PR TITLE
fix type bug -- sample rate should be typed as an int instead of str

### DIFF
--- a/infiniteremixer/segmentation/segment.py
+++ b/infiniteremixer/segmentation/segment.py
@@ -19,7 +19,7 @@ def segment():
     parser.add_argument("save_dir",
                         help="directory where to save generated audio files "
                              "for beats")
-    parser.add_argument("-r", "--sample_rate",
+    parser.add_argument("-r", "--sample_rate", type=int,
                         help="sample rate for processing audio files",
                         default=22050)
 


### PR DESCRIPTION
Without this, any custom sample_rate arg will be defaulted to string and blow up like:

```
  File "/my/project/dirs/infiniteremixer/venv/lib/python3.7/site-packages/resampy/core.py", line 87, in resample
    if sr_new <= 0:
TypeError: '<=' not supported between instances of 'str' and 'int'
```